### PR TITLE
mark small functions as inline

### DIFF
--- a/srcEpos/util.c
+++ b/srcEpos/util.c
@@ -40,15 +40,6 @@ void freeBinom() {
   bin = NULL;
 }
 
-double binomial(int n, int k){
-
-  if(n < k)
-    return 0;
-  else
-    return bin[n][k];
-  
-}
-
 /* fi: Equation (5) */
 double fi(int i, int n, int r, int *k){
   double a, b;
@@ -126,13 +117,6 @@ double watterson(Sfs *sfs, Args *args){
   w = sfs->p / s / 4. / sfs->u / l;
 
   return w;
-}
-
-int max(int a, int b) {
-  if(a > b)
-    return a;
-  else
-    return b;
 }
 
 /* shuffle shuffles the integers contained in array a */

--- a/srcEpos/util.h
+++ b/srcEpos/util.h
@@ -10,7 +10,7 @@
 #include "sfs.h"
 #include "interface.h"
 
-double binomial(int n, int k);
+inline double binomial(int n, int k);
 double fi(int i, int n, int r, int *k);
 double gi(int i, int n, int r, int *k);
 double hi(int i, int n, int r, int *k);
@@ -21,8 +21,25 @@ void printSfsStats(Sfs *sfs);
 double watterson(Sfs *sfs, Args *args);
 void iniBinom(int n);
 void freeBinom();
-int max(int a, int b);
+inline int max(int a, int b);
 void shuffle(int *a, long n, gsl_rng *r);
 void testShuffle(int n, gsl_rng *r);
+
+extern double **bin;
+
+inline double binomial(int n, int k){
+
+  if(__builtin_expect(n < k, 0))
+    return 0;
+  else
+    return bin[n][k];
+}
+
+inline int max(int a, int b) {
+  if(a > b)
+    return a;
+  else
+    return b;
+}
 
 #endif


### PR DESCRIPTION
This makes epos two times faster on the example data sets.